### PR TITLE
Correção do nome do município de Restinga Sêca.

### DIFF
--- a/data/cities.csv
+++ b/data/cities.csv
@@ -4946,7 +4946,7 @@ ibge_code,state_code,name,is_capital,lon,lat,no_accents,alternative_names,micror
 4315354,RS,Quinze de Novembro,,-53.0967220568,-28.7423613499,Quinze de Novembro,,Cruz Alta,Noroeste Rio-Grandense
 4315404,RS,Redentora,,-53.641933694,-27.6615398827,Redentora,,Três Passos,Noroeste Rio-Grandense
 4315453,RS,Relvado,,-52.0729485543,-29.1122786661,Relvado,,Lajeado-Estrela,Centro Oriental Rio-Grandense
-4315503,RS,Restinga Seca,,-53.3705685765,-29.8139485367,Restinga Seca,,Restinga Seca,Centro Ocidental Rio-Grandense
+4315503,RS,Restinga Sêca,,-53.3705685765,-29.8139485367,Restinga Seca,,Restinga Seca,Centro Ocidental Rio-Grandense
 4315552,RS,Rio dos Índios,,-52.8400578928,-27.2983975952,Rio dos Indios,,Frederico Westphalen,Noroeste Rio-Grandense
 4315602,RS,Rio Grande,,-52.0867696991,-32.0504457927,Rio Grande,,Litoral Lagunar,Sudeste Rio-Grandense
 4315701,RS,Rio Pardo,,-52.3790182512,-29.9856258787,Rio Pardo,,Cachoeira do Sul,Centro Oriental Rio-Grandense


### PR DESCRIPTION
Correção do nome do município de Restinga Sêca.
O nome é com acento circunflexo. Essa reportagem trata bem sobre o assunto: https://diariosm.com.br/regi%C3%A3o/o-nome-da-cidade-%C3%A9-assim-restinga-s%C3%AAca-com-acento-1.2010054